### PR TITLE
default fullDump to false to address issues with cron

### DIFF
--- a/src/Model/Db/DbDumper.php
+++ b/src/Model/Db/DbDumper.php
@@ -42,7 +42,7 @@ class DbDumper
      * @param bool $fullDump
      * @throws \Exception
      */
-    public function dumpDb(ProjectMeta $projectMeta, bool $fullDump): void
+    public function dumpDb(ProjectMeta $projectMeta, bool $fullDump = false): void
     {
         $hostName = $this->config->getLocalDbConfigData(ConfigOptionsListConstants::KEY_HOST);
         $dbName   = $this->config->getLocalDbConfigData(ConfigOptionsListConstants::KEY_NAME);

--- a/src/Model/DbFacade.php
+++ b/src/Model/DbFacade.php
@@ -22,7 +22,7 @@ class DbFacade
     /**
      * @throws \Exception
      */
-    public function dumpDatabase(ProjectMeta $projectMeta, bool $fullDump): void
+    public function dumpDatabase(ProjectMeta $projectMeta, bool $fullDump = false): void
     {
         $this->dumper->dumpDb($projectMeta, $fullDump);
     }


### PR DESCRIPTION
## Issue

ArgumentCountError: Too few arguments to function Jh\StrippedDbProvider\Model\DbFacade::dumpDatabase(), 1 passed in <proj_path>/vendor/wearejh/stripped-db-provider/src/Cron/UploadDbCron.php on line 49 and exactly 2 expected in   `<proj_path>1/vendor/wearejh/stripped-db-provider/src/Model/DbFacade.php:25`

## Resolved By

Making `fullDump` default to `false` 