### PR TITLE
Fix success message

### DIFF
--- a/src/Console/ImportFromRemoteCommand.php
+++ b/src/Console/ImportFromRemoteCommand.php
@@ -19,6 +19,8 @@ class ImportFromRemoteCommand extends Command
     private const ARGUMENT_PROJECT_NAME = 'source-project-name';
     private const OPTION_NO_ADMIN_ACCOUNT_BACKUP = 'no-admin-backup';
 
+    private const SUCCESS = 1;
+
     public function __construct(
         private DbFacade $dbFacade,
         string $name = null
@@ -60,7 +62,7 @@ class ImportFromRemoteCommand extends Command
         );
 
         if (!$helper->ask($input, $output, $question)) {
-            return Command::SUCCESS;
+            return self::SUCCESS;
         }
 
         try {
@@ -101,6 +103,6 @@ class ImportFromRemoteCommand extends Command
             }
         }
 
-        return Command::SUCCESS;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION


BUG:
After Restoring local admin accounts ... message getting the , getting the error: Undefined constant Symfony\Component\Console\Command\Command::SUCCESS#


<img width="1237" alt="Screenshot 2024-04-19 at 17 41 16" src="https://github.com/WeareJH/stripped-db-provider/assets/149599506/8aaf7ea0-47f5-4146-a206-8e6e26f6e05f">