### PR TITLE
JDTB-91 Decouple stripped db provider from JH toolkit module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Edit the **env.php** file manually and set the following config (values below ar
     ]
 ```
 
-You can add access_key_id, secret_access_key, cron_exp from admin also by logging in admin. Go to Store->Configuration->JH Modules->DB Provider
+You can add access_key_id, secret_access_key, bucket_name, region from admin also by logging in admin. Go to Store->Configuration->Advanced->Stripped DB Provider
 
 Values are described in the following table:
 

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="stripped_db_provider" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-            <tab>wearejh</tab>
+            <tab>advanced</tab>
             <label>Stripped DB Provider</label>
             <resource>Jh_StrippedDbProvider::config</resource>
             <group id="general" translate="label"  type="text" sortOrder="0" showInDefault="1" showInStore="0" showInWebsite="0">


### PR DESCRIPTION
Moves Stripped DB provider from Store->Configuration->JH Modules-> Stripped DB Provider To 
**Store->Configuration->Advanced-> Stripped DB Provider**.
![Screenshot 2024-08-12 at 10 58 32 AM](https://github.com/user-attachments/assets/16960c52-437b-4063-8456-a585b052e64c)
