### PR TITLE
JDTB-46 Allow to keep core_config_data or cache certain config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,22 @@ reimport them
 bin/magento wearejh:stripped-db-provider:import-from-remote PROJECT NAME 
 ```
 
-To skip admin accounts backup
+#### To skip admin accounts backup
 
 ```
-bin/magento wearejh:stripped-db-provider:import-from-remote PROJECT NAME --no-admin-backup=1
+bin/magento wearejh:stripped-db-provider:import-from-remote PROJECT NAME --no-admin-backup=1 
+```
+
+#### Config backup
+
+The `config-backup` option accepts 3 values:
+* *skip* - skips the backup of local config and imports everything from the remote
+* *merge* - backs up only the paths configured under `stripped_db_provider/dump/config_paths_keep` (accepts MySQL wildcards `%`),
+  imports everything from the remote and merges the backed up config with the remote config
+* *preserve-local* - backs up the whole `core_config_data` and restores it after the DB import from remote
+
+```
+bin/magento wearejh:stripped-db-provider:import-from-remote PROJECT NAME --config-backup=merge
 ```
 
 ## Issues / Feature Request

--- a/src/Console/ImportFromRemoteCommand.php
+++ b/src/Console/ImportFromRemoteCommand.php
@@ -18,6 +18,11 @@ class ImportFromRemoteCommand extends Command
 {
     private const ARGUMENT_PROJECT_NAME = 'source-project-name';
     private const OPTION_NO_ADMIN_ACCOUNT_BACKUP = 'no-admin-backup';
+    private const OPTION_CONFIG_DATA_BACKUP = 'config-backup';
+
+    private CONST VALUE_CONFIG_SKIP = 'skip';
+    private CONST VALUE_CONFIG_PRESERVE = 'preserve-local';
+    private CONST VALUE_CONFIG_MERGE = 'merge';
 
     private const SUCCESS = 1;
 
@@ -47,6 +52,13 @@ class ImportFromRemoteCommand extends Command
             'Set this flag to skip backup of local admin accounts',
             false
         );
+        $this->addOption(
+            self::OPTION_CONFIG_DATA_BACKUP,
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Set this flag to back up the whole core_config_data table',
+            self::VALUE_CONFIG_MERGE
+        );
     }
 
     /**
@@ -68,6 +80,7 @@ class ImportFromRemoteCommand extends Command
         try {
             $sourceProjectMeta = new ProjectMeta($input->getArgument(self::ARGUMENT_PROJECT_NAME));
             $backupAdminAccounts = !$input->getOption(self::OPTION_NO_ADMIN_ACCOUNT_BACKUP);
+            $backupConfig = $this->getConfigBackupOption($input);
 
             $output->writeln('<fg=cyan;options=bold>Downloading Database From Cloud Storage...</>');
             $this->dbFacade->downloadDatabaseDump($sourceProjectMeta);
@@ -84,6 +97,14 @@ class ImportFromRemoteCommand extends Command
                 $this->dbFacade->backupLocalAdminAccounts($sourceProjectMeta);
             }
 
+            if ($backupConfig === self::VALUE_CONFIG_PRESERVE) {
+                $output->writeln('<fg=cyan;options=bold>Backing up config ...</>');
+                $this->dbFacade->backupLocalConfig($sourceProjectMeta);
+            } else if ($backupConfig === self::VALUE_CONFIG_MERGE) {
+                $output->writeln('<fg=cyan;options=bold>Backing up preconfigured config paths ...</>');
+                $this->dbFacade->backupConfigValues($sourceProjectMeta);
+            }
+
             $output->writeln("<info>Starting the Database import</info>");
             $this->dbFacade->importDatabaseDump($sourceProjectMeta);
             $output->writeln("<info>Database successfully imported.</info>");
@@ -92,17 +113,37 @@ class ImportFromRemoteCommand extends Command
                 $output->writeln('<fg=cyan;options=bold>Restoring local admin accounts ...</>');
                 $this->dbFacade->restoreLocalAdminAccountsFromBackup($sourceProjectMeta);
             }
+
+            if ($backupConfig === self::VALUE_CONFIG_PRESERVE) {
+                $output->writeln('<fg=cyan;options=bold>Restoring config ...</>');
+                $this->dbFacade->restoreLocalConfigFromBackup($sourceProjectMeta);
+            } else if ($backupConfig === self::VALUE_CONFIG_MERGE) {
+                $output->writeln('<fg=cyan;options=bold>Restoring preconfigured config paths ...</>');
+                $this->dbFacade->restoreConfigValues();
+            }
         } catch (Exception $e) {
             $output->writeln("<error>{$e->getMessage()}</error>");
         } finally {
             if (isset($sourceProjectMeta)) {
                 $this->dbFacade->cleanUpLocalDumpFiles($sourceProjectMeta);
             }
-            if ($backupAdminAccounts) {
+            if (isset($backupAdminAccounts) && $backupAdminAccounts) {
                 $this->dbFacade->cleanUpAdminAccountsBackup($sourceProjectMeta);
+            }
+            if (isset($backupConfig) && $backupConfig === self::VALUE_CONFIG_PRESERVE) {
+                $this->dbFacade->cleanUpConfigBackup($sourceProjectMeta);
             }
         }
 
         return self::SUCCESS;
+    }
+
+    private function getConfigBackupOption(InputInterface $input): string
+    {
+        $configBackupOption = $input->getOption(self::OPTION_CONFIG_DATA_BACKUP);
+        if (!in_array($configBackupOption, [self::VALUE_CONFIG_SKIP, self::VALUE_CONFIG_PRESERVE, self::VALUE_CONFIG_MERGE])) {
+            $configBackupOption = self::VALUE_CONFIG_MERGE;
+        }
+        return $configBackupOption;
     }
 }

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -28,6 +28,7 @@ class Config
      * Dump Specific
      */
     const XML_PATH_PROJECT_IGNORE_TABLES = 'stripped_db_provider/dump/project_ignore_tables';
+    const XML_PATH_PROJECT_KEEP_CONFIG_PATHS = 'stripped_db_provider/dump/config_paths_keep';
 
     public function __construct(
         private readonly ScopeConfigInterface $config,
@@ -76,5 +77,15 @@ class Config
                 $key
             )
         );
+    }
+
+    public function getConfigPathsToKeep(): array
+    {;
+        $defaultPaths = explode(
+            ',',
+            (string) $this->config->getValue(self::XML_PATH_PROJECT_KEEP_CONFIG_PATHS)
+        );
+
+        return array_merge($defaultPaths, $projectIgnoredPaths);
     }
 }

--- a/src/Model/DbFacade.php
+++ b/src/Model/DbFacade.php
@@ -15,7 +15,8 @@ class DbFacade
         private Db\DbUploader $uploader,
         private Db\DbImporter $importer,
         private Db\DbCleaner $cleaner,
-        private Db\DbAdminAccountsManager $adminAccountsManager
+        private Db\DbAdminAccountsManager $adminAccountsManager,
+        private Db\DbConfigBackupManager $configBackupManager
     ) {
     }
 
@@ -82,5 +83,30 @@ class DbFacade
     public function cleanUpAdminAccountsBackup(ProjectMeta $projectMeta): void
     {
         $this->adminAccountsManager->cleanUp($projectMeta);
+    }
+
+    public function backupLocalConfig(ProjectMeta $projectMeta): void
+    {
+        $this->configBackupManager->backupConfig($projectMeta);
+    }
+
+    public function restoreLocalConfigFromBackup(ProjectMeta $projectMeta): void
+    {
+        $this->configBackupManager->restoreConfigBackup($projectMeta);
+    }
+
+    public function cleanUpConfigBackup(ProjectMeta $projectMeta): void
+    {
+        $this->configBackupManager->cleanUp($projectMeta);
+    }
+
+    public function backupConfigValues(): void
+    {
+        $this->configBackupManager->cacheConfigValuesToKeep();
+    }
+
+    public function restoreConfigValues(): void
+    {
+        $this->configBackupManager->restoreConfigValuesToKeep();
     }
 }

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -7,6 +7,9 @@
                 <secret_access_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"></secret_access_key>
                 <access_key_id backend_model="Magento\Config\Model\Config\Backend\Encrypted"></access_key_id>
             </storage>
+            <dump>
+                <config_paths_keep>payment/%</config_paths_keep>
+            </dump>
         </stripped_db_provider>
     </default>
 </config>


### PR DESCRIPTION
Added 2 new features:

* The ability to backup entire core_config_data table before the import 
* The default ability to cache certain config values in memory and restore them after import (by default, `payment/%` paths are cached)