### PR TITLE
JDTB-116 Admin account restore successfully

### DIFF
--- a/src/Model/Db/DbAdminAccountsManager.php
+++ b/src/Model/Db/DbAdminAccountsManager.php
@@ -34,6 +34,7 @@ class DbAdminAccountsManager
             [
                 'skip-definer' => true,
                 'add-drop-table' => true,
+                'skip-triggers' => true,
                 'include-tables' => [
                     'admin_passwords',
                     'admin_system_messages',


### PR DESCRIPTION
**Description**: Getting the below error while importing DB from remote `SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'DELIMITER' at line 1`

![image](https://github.com/user-attachments/assets/074d323a-8db0-450d-99bb-3f757fedeb14)

**Changes**: I added `skip-triggers` option so that triggers are not included in the dump, which would fixed issue for DELIMITER