### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/src/Console/ImportFromRemoteCommand.php
+++ b/src/Console/ImportFromRemoteCommand.php
@@ -28,7 +28,7 @@ class ImportFromRemoteCommand extends Command
 
     public function __construct(
         private DbFacade $dbFacade,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
     }

--- a/src/Console/UploadToRemoteCommand.php
+++ b/src/Console/UploadToRemoteCommand.php
@@ -14,7 +14,7 @@ class UploadToRemoteCommand extends Command
 {
     private const OPTION_FULL_DUMP = 'full';
 
-    public function __construct(private DbFacade $dbFacade, private Config $config, string $name = null)
+    public function __construct(private DbFacade $dbFacade, private Config $config, ?string $name = null)
     {
         parent::__construct($name);
     }


### PR DESCRIPTION
PHP 8.4 deprecates implicit nullable parameters (`Type $param = null`). This adds an explicit `?Type` prefix to all affected signatures.                                                                                             
                                                                 
Required for Magento 2.4.8 on PHP 8.4 - Magento's ErrorHandler throws on `E_DEPRECATED`, making these fatal.